### PR TITLE
Make Date type not break.

### DIFF
--- a/src/typed.js
+++ b/src/typed.js
@@ -140,6 +140,15 @@ Typed.Boolean = Typed("Boolean", value =>
   value === false ? false :
   TypeError(`"${value}" is not a boolean`))
 
+Typed.Date = Typed("Date", value => {
+  var d = new Date(value)
+  if (isNaN(d.valueOf())) {
+    return new TypeError(`"${value}" is not a valid date.`)
+  }
+  return d
+})
+
+
 class MaybeType extends Type {
   constructor(type) {
     super()


### PR DESCRIPTION
Currently, the use of `Date` as a type in a Record breaks, because there is a reference to `Typed.Date`, which is never actually defined.

This pull request defines it.