### PR TITLE
Allow Record subclasses

### DIFF
--- a/src/record.js
+++ b/src/record.js
@@ -44,9 +44,7 @@ class TypedRecord extends IterableKeyedBase {
   [Typed.read](structure) {
     const Type = this.constructor
 
-    if (structure instanceof Type &&
-        structure &&
-        structure.constructor === Type) {
+    if (structure && structure instanceof Type) {
       return structure
     }
 


### PR DESCRIPTION
This request is a replacement for #25, because in trying to set up and test the Travis stuff, I somehow broke the branch.

This change allows subclasses of a Record type to satisfy checks within typed-immutable.
Currently, in typed-immutable, if you have a situation such as:

```var A = Record({foo: Number});
class B extends A {}```

And another composite record:

```var MyRecord = Record({a: A});```

If you send a `B` instance, it will not throw `TypeError`, but the instance is typecast back to `A`.

This change fixes that; it remains a `B` instance.