### PR TITLE
Add List.insert and upgrade Immutable.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "immutable": ">=3.8.1"
+    "immutable": ">=3.7.6"
   },
   "devDependencies": {
     "babel": "5.6.14",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "immutable": "3.7.0"
+    "immutable": ">=3.8.1"
   },
   "devDependencies": {
     "babel": "5.6.14",

--- a/src/list.js
+++ b/src/list.js
@@ -130,7 +130,7 @@ class TypeInferedList extends BaseImmutableList {
   }
 
   get(index, notSetValue) {
-    return this[$store] ? this[$store].get(index, notSetValue) :
+    return this[$store] ? this[$store].get(parseInt(index), notSetValue) :
            notSetValue
   }
 
@@ -142,13 +142,27 @@ class TypeInferedList extends BaseImmutableList {
     return this[$empty] || this[$read]()
   }
 
+  insert(index, value) {
+    if (index > this.size) {
+      throw TypeError(`Index "${index}" is out of bounds.`)
+    }
+
+    const result = this[$type][$read](value)
+
+    if (result instanceof TypeError) {
+      throw TypeError(`Invalid value: ${result.message}`)
+    }
+
+    return change(this, store => store.insert(index, value))
+  }
+
   remove(index) {
     return change(this, store => store && store.remove(index))
   }
 
   set(index, value) {
     if (index > this.size) {
-      throw TypeError(`Index "${index}" is out of bound`)
+      throw TypeError(`Index "${index}" is out of bounds.`)
     }
 
     const result = this[$type][$read](value)

--- a/src/test/list.js
+++ b/src/test/list.js
@@ -545,6 +545,17 @@ test('push inserts at highest index', assert => {
   assert.deepEqual(v1.toArray(), [1, 2, 3, 4, 5, 6])
 })
 
+test('insert inserts where told', assert => {
+  const v0 = NumberList.of(1, 2, 3, 4, 5)
+  const v1 = v0.insert(2, 50)
+
+  assert.ok(v0 instanceof NumberList)
+  assert.ok(v1 instanceof NumberList)
+
+  assert.deepEqual(v0.toArray(), [1, 2, 3, 4, 5])
+  assert.deepEqual(v1.toArray(), [1, 2, 50, 3, 4, 5])
+})
+
 test('pop removes the highest index, decrementing size', assert => {
   const v0 = NumberList.of(1, 2, 3)
   const v1 = v0.pop()


### PR DESCRIPTION
This commit upgrades Immutable to 3.8.1, and sets it to `>=` in
`package.json`.

It also adds a `List.insert()` method to typed-immutable lists.

FIxes #20.