### PR TITLE
[WIP] auto formatter

### DIFF
--- a/autoformat.js
+++ b/autoformat.js
@@ -1,0 +1,18 @@
+var exec = require('child-process-promise').exec;
+
+exec('git status --porcelain')
+.then(status => {
+  status = status.stdout.trim();
+  if (status.length) {
+    throw new Error('You must not have any uncommited changes to run autoformat.');
+  }
+})
+.then(() => exec('esformatter ./src/*.js ./src/**/*.js -i'))
+.then(() => exec('git commit -am "autoformatting"'))
+.then(() =>  {
+  console.log('Autoformatting was successful. Please push the changes.');
+})
+.catch(err => {
+  console.log('Could not autoformat.');
+  console.error(err);
+});

--- a/package.json
+++ b/package.json
@@ -32,13 +32,16 @@
     "test": "tap lib/test/*.js",
     "start": "babel --watch --optional spec.protoToAssign --modules umdStrict --source-maps inline --out-dir ./lib ./src",
     "build": "babel --optional spec.protoToAssign --modules umdStrict --source-maps inline --out-dir ./lib ./src",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "format": "node autoformat.js"
   },
   "dependencies": {
     "immutable": ">=3.7.6"
   },
   "devDependencies": {
     "babel": "5.6.14",
+    "child-process-promise": "^1.1.0",
+    "esformatter": "^0.9.6",
     "tap": "~0.4.8",
     "tape": "~2.3.2"
   }


### PR DESCRIPTION
This is the start of the auto formatter so that when people contribute we can ask them to `npm run format` as the last step of their PR. This way we will have consistent code without having to worry about forcing people to use our linter, switching between double and single quotes, etc. It will also be easy to tell if people are using it because the last commit should have the message 'autoformatting'.

I will make an esformatter.json and configure it to make as few changes as possible to our current code.