### PR TITLE
Release 0.0.8

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,14 @@
+typed-immutable was originally written by:
+
+    Irakli Gozalishvili (GitHub: @Gozala)
+
+It is now being maintained by:
+
+    Dave Coates (GitHub: @davecoates)
+    Stu Kabakoff (GitHub: @stutrek)
+    Pasindu Perera (GitHub: @udnisap)
+    Luke Sneeringer (GitHub: @lukesneeringer)
+
+Other contributors include:
+
+    Don Abrams (GitHub: @donabrams)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+### Release 0.0.8
+
+The `typed-immutable` maintainers are pleased to release a minor upgrade
+and bugfix release for `typed-immutable`. It includes the following changes:
+
+  * Added support for `Map.flatten`. [@davecoates, #15]
+  * Added a new `Map` type, with an invocation like `Map(String, MyRecord)`,
+    to allow for records with a map of arbitrary keys but typed records.
+    [@davecoates, #19]
+  * Fixed a bug when using `Date`. [@lukesneeringer, #22]
+  * Passing a subclass of the expected type to a Record now preserves
+    the subclass instance (rather than typecasting to the superclass).
+    [@lukesneeringer, #26]
+  * Immutable.js is upgraded to 3.7.6 (from 3.7.0), with the option of using
+    any later version. [@lukesneeringer, #29]
+  * `List.insert`, added in Immutable.js 3.7.6, is now supported in
+    typed-immutable lists. [@lukesneeringer, #29]
+
+The new team of maintainers is also in the process of instituting processes
+for more regular releases.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+                             The MIT License
+
+Copyright (c) 2015-2016, typed-immutable contributors and maintainers
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "typed-immutable",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Immutable structurally typed data",
   "author": "Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)",
-  "homepage": "https://github.com/gozala/typed-immutable",
+  "homepage": "https://github.com/typed-immutable/typed-immutable",
   "keywords": [
     "record",
     "structure",


### PR DESCRIPTION
Adds:

* A license file (required to be included by the MIT license, which
is what was in package.json).
* A changelog (only for 0.0.8, sadly).
* An authors file.
* Version bump in package.json

After we all decide we like this, I will push it to npm manually.