### PR TITLE
Support Immutables in records.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+### Release 0.1.0
+
+The `typed-immutable` maintainers are pleased to release a feature release
+for `typed-immutable`. It includes the following changes:
+
+  * Added support for the use of Immutable objects or classes in records.
+    [@lukesneeringer, #40]
+
+
+### Release 0.0.9
+
+The `typed-immutable` maintainers are pleased to release a minor upgrade
+and bugfix release for `typed-immutable`. It includes the following changes:
+
+  * Added support for `Map.merge` [@davecoates, #36]
+
 ### Release 0.0.8
 
 The `typed-immutable` maintainers are pleased to release a minor upgrade

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-immutable",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "Immutable structurally typed data",
   "author": "Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)",
   "homepage": "https://github.com/typed-immutable/typed-immutable",


### PR DESCRIPTION
This PR adds support for the use of immutables in records:

```javascript
import {Record} from 'typed-immutable';

var MyRecord = Record({
  mapName: Immutable.Map,
});
```

The object form (e.g. `new Immutable.Map()`) also works, if you wish to provide a default.

This allows the original Immutable objects to be used within typed-immutable records when appropriate. The above would roughly be equivalent to `Map(Any, Any)`, and `Immutable.List` would be equivalent to `List(Any)`; however, we will no longer incur the overhead of using our own objects in these cases when we do not need the typing system.

Additionally, any additional objects Immutable provides, now or in the future, work. So, for instance, this supports `Immutable.Set`.