### PR TITLE
Allow Lists, Maps, and Records to coexist in a Union

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 
 # build artifacts
 **/lib/*
+
+.idea

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -1,5 +1,7 @@
 import test from "./test"
 import * as Immutable from "immutable"
+import {List} from "../list"
+import {Map} from "../map"
 import {Record} from "../record"
 import {Typed, typeOf, Union, Range, Maybe} from "../typed"
 
@@ -566,4 +568,25 @@ test("Union of similar records", assert => {
   assert.equal(Action({action: add}).action, add, "recognizes Add")
   assert.equal(Action({action: remove}).action, remove, "recognizes Remove")
   assert.ok(Action({action: ambigius}).action instanceof Add, "matches Add")
+})
+
+test("Union of lists, maps, and records", assert => {
+  const MyList = List(Number(0))
+  const MyMap = Map(String, String)
+  const MyRecord = Record({id: Number(0)})
+  const Action = Record({action: Union(MyList, MyMap, MyRecord)})
+
+  const myList = MyList()
+  const myMap = MyMap()
+  const myRecord = MyRecord()
+  const ambiguousList = [5]
+  const ambiguousMap = {id: 'foo'}
+  const ambiguousRecord = {id: 1}
+
+  assert.equal(Action({action: myList}).action, myList, "recognizes MyList")
+  assert.equal(Action({action: myMap}).action, myMap, "recognizes MyMap")
+  assert.equal(Action({action: myRecord}).action, myRecord, "recognizes MyRecord")
+  assert.ok(Action({action: ambiguousList}).action instanceof MyList, "matches MyList")
+  assert.ok(Action({action: ambiguousList}).action instanceof MyList, "matches MyMap")
+  assert.ok(Action({action: ambiguousRecord}).action instanceof MyRecord, "matches MyRecord")
 })

--- a/src/typed.js
+++ b/src/typed.js
@@ -220,9 +220,16 @@ class UnionType extends Type {
 
     index = 0
     while (index < count) {
-      const result = variants[index][$read](value)
-      if (!(result instanceof TypeError)) {
-        return result
+      let result
+      try {
+        result = variants[index][$read](value)
+        if (!(result instanceof TypeError)) {
+          return result
+        }
+      } catch (ex) {
+        if (!(ex instanceof TypeError)) {
+          throw ex
+        }
       }
       index = index + 1
     }


### PR DESCRIPTION
Currently, Lists, Maps, and Records cannot coexist in a Union because the $read method for these can throw TypeErrors rather than returning them.  The Immutable.js List constructor will throw a TypeError when attempting to initialize a list with a non-array-type object, exiting the Union while loop prematurely (before it tests against the other types).  This PR adds a try/catch around the $read and swallows any TypeErrors that come out of it.  Other error types are thrown so they can be caught up the call stack.